### PR TITLE
remove fetch_diagnostic fn from api::database

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           repository: project-tsurugi/jogasaki
           path: third_party/temp_jogasaki
-          ref: 6033bd9774a8a1c6e749b2b48e96a10009ebf35d
+          ref: f671e3264e83cf008a1788b01430a8595e0cd63a
           submodules: recursive
           token: ${{ secrets.GHA_PAT }}
 

--- a/test/ogawayama/bridge/database_mock.cpp
+++ b/test/ogawayama/bridge/database_mock.cpp
@@ -98,10 +98,6 @@ std::shared_ptr<class jogasaki::configuration>& database_mock::config() noexcept
     return cfg_;
 }
 
-[[nodiscard]] std::shared_ptr<jogasaki::diagnostics> database_mock::fetch_diagnostics() noexcept {
-    return nullptr;
-}
-
 void database_mock::print_diagnostic(std::ostream&) {
 }
 

--- a/test/ogawayama/bridge/database_mock.h
+++ b/test/ogawayama/bridge/database_mock.h
@@ -96,8 +96,6 @@ public:
 
     std::shared_ptr<class jogasaki::configuration>& config() noexcept override;
 
-    [[nodiscard]] std::shared_ptr<jogasaki::diagnostics> fetch_diagnostics() noexcept override;
-
     void print_diagnostic(std::ostream& os) override;
 
     std::string diagnostic_string() override;


### PR DESCRIPTION
@t-horikawa 最近の変更でjogasakiにerror_infoクラスを導入したため、jogasaki::api::databaseから暫定的に使っていたfetch_diagnostics関数を削除しました。問題なければマージお願いします。