### PR TITLE
build: make RPATH relative

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -115,7 +115,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -135,7 +135,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -145,7 +145,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -175,7 +175,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -185,7 +185,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -205,7 +205,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -215,7 +215,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -226,7 +226,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DDATA_STORAGE=json -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DDATA_STORAGE=json -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -237,6 +237,6 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ available options:
 * `-DBUILD_STUB_ONLY=ON` - build the stub only
 * `-DBUILD_BRIDGE_ONLY=ON` - build the bridge only
 * `-DBUILD_TESTS=OFF` - never build test programs
-* `-DFORCE_INSTALL_RPATH=ON` - force set RPATH for non-default library paths
 * `-DBUILD_EXAMPLES=ON` - also build example programs
 * `-DCMAKE_PREFIX_PATH=<installation directory>` - indicate prerequiste installation directory
 * `-DSHARKSFIN_IMPLEMENTATION=<implementation name>` - switch sharksfin implementation. Available options are `memory` and `shirakami` (default: `shirakami`)

--- a/bridge/src/CMakeLists.txt
+++ b/bridge/src/CMakeLists.txt
@@ -20,8 +20,10 @@ add_library(bridge
     ${SOURCES}
 )
 
-set_target_properties(bridge PROPERTIES
-    OUTPUT_NAME "ogawayama-bridge-${SHARKSFIN_IMPLEMENTATION}"
+set_target_properties(bridge
+    PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/../lib"
+        OUTPUT_NAME "ogawayama-bridge-${SHARKSFIN_IMPLEMENTATION}"
 )
 
 target_include_directories(bridge

--- a/cmake/InstallOptions.cmake
+++ b/cmake/InstallOptions.cmake
@@ -28,37 +28,6 @@ function(install_custom target_name export_name)
             DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT Runtime
     )
-    # Add INSTALL_RPATH from CMAKE_INSTALL_PREFIX and CMAKE_PREFIX_PATH
-    # The default behavior of CMake omits RUNPATH if it is already in CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES.
-    if (FORCE_INSTALL_RPATH)
-        get_target_property(target_type ${target_name} TYPE)
-        if (target_type STREQUAL "SHARED_LIBRARY"
-                OR target_type STREQUAL "EXECUTABLE")
-            get_target_property(rpath ${target_name} INSTALL_RPATH)
-
-            # add ${CMAKE_INSTALL_PREFIX}/lib if it is not in system link directories
-            get_filename_component(p "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-            list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${p}" is_system)
-            if (is_system STREQUAL "-1")
-                list(APPEND rpath "${p}")
-            endif()
-
-            # add each ${CMAKE_PREFIX_PATH}/lib
-            foreach (p IN LISTS CMAKE_PREFIX_PATH)
-                get_filename_component(p "${p}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-                list(APPEND rpath "${p}")
-            endforeach()
-
-            if (rpath)
-                set_target_properties(${target_name} PROPERTIES
-                    INSTALL_RPATH "${rpath}")
-            endif()
-
-            # add other than */lib paths
-            set_target_properties(${target_name} PROPERTIES
-                INSTALL_RPATH_USE_LINK_PATH ON)
-        endif()
-    endif (FORCE_INSTALL_RPATH)
     # Install include files of interface libraries manually
     # INTERFACE_INCLUDE_DIRECTORIES must contains the following entries:
     # - one or more `$<BUILD_INTERFACE:...>` paths (may be absolute paths on source-tree)

--- a/examples/cli/CMakeLists.txt
+++ b/examples/cli/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(cli
 
 set_target_properties(cli
     PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/../lib"
         RUNTIME_OUTPUT_NAME "ogawayama-cli"
 )
 

--- a/examples/tpcc/CMakeLists.txt
+++ b/examples/tpcc/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(tpcc
 
 set_target_properties(tpcc
     PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/../lib"
         RUNTIME_OUTPUT_NAME "ogawayama-tpcc"
 )
 

--- a/examples/tpcc_loader/CMakeLists.txt
+++ b/examples/tpcc_loader/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(tpcc-loader
 
 set_target_properties(tpcc-loader
     PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/../lib"
         RUNTIME_OUTPUT_NAME "ogawayama-tpcc-loader"
 )
 

--- a/mock/src/CMakeLists.txt
+++ b/mock/src/CMakeLists.txt
@@ -27,6 +27,7 @@ target_include_directories(stub-mock
 
 set_target_properties(stub-mock
     PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/../lib"
         LIBRARY_OUTPUT_NAME "ogawayama-stub-mock"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ add_dependencies(stub
 
 set_target_properties(stub
     PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/../lib"
         LIBRARY_OUTPUT_NAME "ogawayama-stub"
 )
 


### PR DESCRIPTION
This Pull Request modifies CMake Property `INSTALL_RPATH` to relative path based `$ORIGIN`, and changes to disable unnecessary CMake Property `FORCE_INSTALL_RPATH`.