### PR TITLE
build: fix RPATH settings to work even if libdir is not "lib"

### DIFF
--- a/bridge/src/CMakeLists.txt
+++ b/bridge/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2019 tsurugi project.
+# Copyright 2019-2025 tsurugi project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ add_library(bridge
 
 set_target_properties(bridge
     PROPERTIES
-        INSTALL_RPATH "\$ORIGIN/../lib"
+        INSTALL_RPATH "\$ORIGIN"
         OUTPUT_NAME "ogawayama-bridge-${SHARKSFIN_IMPLEMENTATION}"
 )
 

--- a/examples/cli/CMakeLists.txt
+++ b/examples/cli/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2019 tsurugi project.
+# Copyright 2019-2025 tsurugi project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ add_executable(cli
 
 set_target_properties(cli
     PROPERTIES
-        INSTALL_RPATH "\$ORIGIN/../lib"
+        INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
         RUNTIME_OUTPUT_NAME "ogawayama-cli"
 )
 

--- a/examples/tpcc/CMakeLists.txt
+++ b/examples/tpcc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 tsurugi project.
+# Copyright 2019-2025 tsurugi project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ add_executable(tpcc
 
 set_target_properties(tpcc
     PROPERTIES
-        INSTALL_RPATH "\$ORIGIN/../lib"
+        INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
         RUNTIME_OUTPUT_NAME "ogawayama-tpcc"
 )
 

--- a/examples/tpcc_loader/CMakeLists.txt
+++ b/examples/tpcc_loader/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2019 tsurugi project.
+# Copyright 2019-2025 tsurugi project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ add_executable(tpcc-loader
 
 set_target_properties(tpcc-loader
     PROPERTIES
-        INSTALL_RPATH "\$ORIGIN/../lib"
+        INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
         RUNTIME_OUTPUT_NAME "ogawayama-tpcc-loader"
 )
 

--- a/mock/src/CMakeLists.txt
+++ b/mock/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2019 tsurugi fin project.
+# Copyright 2019-2025 tsurugi fin project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ target_include_directories(stub-mock
 
 set_target_properties(stub-mock
     PROPERTIES
-        INSTALL_RPATH "\$ORIGIN/../lib"
+        INSTALL_RPATH "\$ORIGIN"
         LIBRARY_OUTPUT_NAME "ogawayama-stub-mock"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 tsurugi fin project.
+# Copyright 2019-2025 tsurugi fin project.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ add_dependencies(stub
 
 set_target_properties(stub
     PROPERTIES
-        INSTALL_RPATH "\$ORIGIN/../lib"
+        INSTALL_RPATH "\$ORIGIN"
         LIBRARY_OUTPUT_NAME "ogawayama-stub"
 )
 


### PR DESCRIPTION
Tsurugi が主にサポートしている Ubuntu では、インストールディレクトリの下に `lib` ディレクトリを作成し、そこに共有ライブラリファイルを配置しますが、
RHEL 派生 Linux ディストリビューション等では、これが `lib64` ディレクトリとなるため、 INSTALL_RPATH で指定している場所と異なり起動時に問題となることがあります。

関連案件: project-tsurugi/tsurugi-issues#1066

この問題に対処する修正です。
