### PR TITLE
ci: change Analysis job env to almalinux/clang

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: Checkout_Yakushima
       uses: actions/checkout@v4
-      if: ${{ inputs.checkout == 'true' }}
+      if: ${{ inputs.checkout == 'true' && inputs.sharksfin_implementation == 'shirakami' }}
       with:
         repository: project-tsurugi/yakushima
         path: ${{ inputs.path }}/yakushima
@@ -64,7 +64,7 @@ runs:
 
     - name: Checkout_Shirakami
       uses: actions/checkout@v4
-      if: ${{ inputs.checkout == 'true' }}
+      if: ${{ inputs.checkout == 'true' && inputs.sharksfin_implementation == 'shirakami' }}
       with:
         repository: project-tsurugi/shirakami
         path: ${{ inputs.path }}/shirakami
@@ -163,6 +163,7 @@ runs:
       shell: bash
 
     - name: Install_Yakushima
+      if: ${{ inputs.sharksfin_implementation == 'shirakami' }}
       run: |
         cd ${{ inputs.path }}/yakushima
         rm -fr build
@@ -173,6 +174,7 @@ runs:
       shell: bash
 
     - name: Install_Shirakami
+      if: ${{ inputs.sharksfin_implementation == 'shirakami' }}
       run: |
         cd ${{ inputs.path }}/shirakami
         rm -fr build
@@ -212,7 +214,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin_implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin_implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
         cmake --build . --target install --clean-first
       shell: bash
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -69,7 +69,7 @@ jobs:
       checks: write
     timeout-minutes: 30
     container:
-      image: ghcr.io/project-tsurugi/tsurugi-ci:ubuntu-22.04
+      image: ghcr.io/project-tsurugi/tsurugi-ci:almalinux-latest
       volumes:
         - ${{ vars.ccache_dir }}:${{ vars.ccache_dir }}
     defaults:
@@ -77,7 +77,9 @@ jobs:
         shell: bash
     env:
       CCACHE_CONFIGPATH: ${{ vars.ccache_dir }}/ccache.conf
-      CCACHE_DIR: ${{ vars.ccache_dir }}/ubuntu-22.04
+      CCACHE_DIR: ${{ vars.ccache_dir }}/almalinux-latest
+      CC: clang
+      CXX: clang++
       SHARKSFIN_IMPLEMENTATION: memory
 
     steps:
@@ -97,12 +99,12 @@ jobs:
           rm -rf build
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${SHARKSFIN_IMPLEMENTATION} -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ${{ inputs.cmake_build_option }} ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${SHARKSFIN_IMPLEMENTATION} -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_TESTS=OFF -DBUILD_STRICT=OFF ${{ inputs.cmake_build_option }} ..
           cmake --build . --target all --clean-first
 
       - name: Clang-Tidy
         run: |
-          python tools/bin/run-clang-tidy.py -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(common|server|stub/include|bridge)/.*\\.h$' $(pwd)'/(common|server|stub/src|bridge)/.*\\.cpp$' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
+          python3 tools/bin/run-clang-tidy.py -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(bridge|common|include|src)/.*\.h$' $(pwd)'/(bridge|src)/.*\.cpp$' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
 
       # - name: Doxygen
       #   run: |


### PR DESCRIPTION
CI environment changes to enable build compatibility verification with Clang on AlmaLinux and static analysis with new version of Clang-Tidy on Analysis job.